### PR TITLE
Create README.md

### DIFF
--- a/part2_prompt_templates/README.md
+++ b/part2_prompt_templates/README.md
@@ -1,0 +1,47 @@
+# Prompt Template Examples
+
+This directory contains examples of how to create and use `ChatPromptTemplate` with LangChain for generating prompts for models.
+
+## prompt_template_example.py
+
+This script demonstrates various ways to create a `ChatPromptTemplate` using template strings and lists of messages. The examples are designed to show how to generate prompts for a model, specifically for cybersecurity topics.
+
+### Examples
+
+1. **Prompt from Template**
+   - Uses a template string with a placeholder for the topic.
+   - Example: "Explain the security concept {topic}."
+   - Generates a prompt explaining the security concept of "XSS attacks".
+
+2. **Prompt with Multiple Placeholders**
+   - Uses a template string with multiple placeholders for adjectives and vulnerabilities.
+   - Example: "Create a {adjective} explanation about a {vulnerability}."
+   - Generates a detailed explanation about an XSS vulnerability.
+
+3. **Prompt with System and Human Messages (Using Tuples)**
+   - Uses a list of messages with system and human messages as tuples.
+   - Example: System message for setting context and human message for specific instructions.
+   - Generates obfuscation technique examples for a specified vulnerability type (XSS) and count.
+
+### Usage
+
+Ensure you have the required libraries installed and environment variables set up as specified in the `.env` file.
+
+Run the script:
+```bash
+python prompt_template_example.py
+```
+
+This will execute the examples and print the generated prompts and model responses.
+
+### Dependencies
+
+- `dotenv`: For loading environment variables.
+- `langchain`: For creating and managing prompt templates.
+- `langchain_openai`: For interacting with the OpenAI model.
+
+### Instructor
+
+Omar Santos [@santosomar](https://github.com/santosomar)
+
+For more information on LangChain Prompt Templates, refer to the [LangChain Prompt Template Documentation](https://python.langchain.com/v0.2/docs/concepts/#prompt-templates).


### PR DESCRIPTION
This pull request adds a new README file to the `part2_prompt_templates` directory, providing examples and instructions for creating and using `ChatPromptTemplate` with LangChain for generating model prompts.

Documentation updates:

* [`part2_prompt_templates/README.md`](diffhunk://#diff-b58d721289daeb4f4c266099d9347f1e9c9f51458cb923570763974628d8b867R1-R47): Added a new README file that includes examples of creating `ChatPromptTemplate` using template strings and lists of messages, specifically for cybersecurity topics. It also provides instructions on usage, dependencies, and references to further documentation.