### PR TITLE
Add cybersecurity MCP example

### DIFF
--- a/part5_agents_and_tools/mcp_servers_examples/README.md
+++ b/part5_agents_and_tools/mcp_servers_examples/README.md
@@ -32,9 +32,9 @@ lightweight nmap scan or answer general questions using OpenAI models.
    ```
 2. Ensure `nmap` is installed (e.g. `sudo apt-get install nmap`).
 3. Run the server:
+   First, navigate to the directory containing `mcp_server.py`:
    ```bash
-   python mcp_server.py
-   ```
+   cd part5_agents_and_tools/mcp_servers_examples
 4. Send a request to the `/scan` endpoint. Example:
    ```bash
    curl -X POST -H "Content-Type: application/json" \

--- a/part5_agents_and_tools/mcp_servers_examples/README.md
+++ b/part5_agents_and_tools/mcp_servers_examples/README.md
@@ -1,0 +1,47 @@
+# MCP Server Cybersecurity Example
+
+This folder contains an example of a minimal **MCP (Master Control Program)**
+implementation inspired by the "[MCP From Scratch](https://mirror-feeling-d80.notion.site/MCP-From-Scratch-1b9808527b178040b5baf83a991ed3b2)"
+article.  The focus here is on cybersecurity use cases.
+
+The example demonstrates how to create a simple FastAPI server that exposes
+endpoints backed by a small LangChain agent.  The agent can perform a
+lightweight nmap scan or answer general questions using OpenAI models.
+
+> **Note**: This example is intentionally simple and should not be used for real
+> security assessments. It is only meant to demonstrate how an MCP-style server
+> can be structured for cybersecurity tasks.
+
+## Files
+
+- `mcp_cyber_agent.py` – LangChain agent with port scanning and time tools.
+- `mcp_server.py` – FastAPI server exposing `/scan` and `/agent` endpoints.
+
+## Prerequisites
+
+- Python 3.x
+- `nmap` installed on your system
+- Python packages from `requirements.txt`
+- An OpenAI API key set in the `.env` file
+
+## Usage
+
+1. Install the required packages:
+   ```bash
+   pip install -r ../../requirements.txt
+   ```
+2. Ensure `nmap` is installed (e.g. `sudo apt-get install nmap`).
+3. Run the server:
+   ```bash
+   python mcp_server.py
+   ```
+4. Send a request to the `/scan` endpoint. Example:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"target": "192.168.1.1"}' http://localhost:8000/scan
+   ```
+5. You can also query the agent directly:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" \
+        -d '{"question": "What time is it?"}' http://localhost:8000/agent
+   ```

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
@@ -16,9 +16,8 @@ from dotenv import load_dotenv
 import nmap
 from langchain import hub
 from langchain.agents import AgentExecutor, create_react_agent
-from langchain_core.tools import Tool
+from langchain.tools import Tool, StructuredTool
 from langchain_openai import ChatOpenAI
-from langchain.tools import StructuredTool
 from pydantic import BaseModel, Field
 
 load_dotenv()  # Load environment variables like OPENAI_API_KEY

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
@@ -1,0 +1,87 @@
+"""Cybersecurity MCP example based on the 'MCP From Scratch' article.
+
+This script shows how to build a minimal Master Control Program (MCP)
+for cybersecurity tasks using LangChain. The agent is equipped with a
+port scanning tool that leverages `nmap` as well as a simple time
+utility. It follows the structure from the original article but focuses
+on cybersecurity use cases.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import List
+
+from dotenv import load_dotenv
+import nmap
+from langchain import hub
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.tools import Tool
+from langchain_openai import ChatOpenAI
+from langchain.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+load_dotenv()  # Load environment variables like OPENAI_API_KEY
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+def get_current_time(*args, **kwargs) -> str:
+    """Return the current time in H:MM AM/PM format."""
+    now = datetime.datetime.now()
+    return now.strftime("%I:%M %p")
+
+
+def scan_ports(ip: str) -> str:
+    """Scan ``ip`` using nmap and return a list of open ports."""
+    nm = nmap.PortScanner()
+    try:
+        nm.scan(ip, arguments="-F")
+    except Exception as exc:  # pragma: no cover - depends on system nmap
+        return f"Error running nmap: {exc}"
+
+    open_ports: List[int] = []
+    if ip in nm.all_hosts():
+        for proto in nm[ip].all_protocols():
+            open_ports.extend(nm[ip][proto].keys())
+    return f"Open ports for {ip}: {sorted(open_ports)}"
+
+
+class ScanInput(BaseModel):
+    ip: str = Field(..., description="IP address to scan")
+
+
+# Register tools with LangChain
+TOOLS = [
+    Tool(name="Time", func=get_current_time, description="Get the current time"),
+    StructuredTool(
+        name="PortScanner",
+        func=scan_ports,
+        description="Scan an IP address for open ports using nmap",
+        args_schema=ScanInput,
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Agent setup
+# ---------------------------------------------------------------------------
+
+PROMPT = hub.pull("hwchase17/react")
+LLM = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+
+AGENT = create_react_agent(llm=LLM, tools=TOOLS, prompt=PROMPT, stop_sequence=True)
+AGENT_EXECUTOR = AgentExecutor.from_agent_and_tools(agent=AGENT, tools=TOOLS, verbose=True)
+
+
+def invoke_agent(question: str) -> str:
+    """Run the agent with the provided ``question`` and return its output."""
+    result = AGENT_EXECUTOR.invoke({"input": question})
+    return result["output"]
+
+
+if __name__ == "__main__":  # pragma: no cover - example usage
+    import sys
+
+    query = sys.argv[1] if len(sys.argv) > 1 else "What time is it?"
+    print(invoke_agent(query))

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
@@ -1,0 +1,37 @@
+"""Minimal MCP server example for cybersecurity.
+
+This FastAPI application exposes endpoints that leverage a simple MCP
+agent to perform cybersecurity tasks.  The `/scan` endpoint uses the
+agent to run a lightweight nmap scan on the provided target.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .mcp_cyber_agent import invoke_agent
+
+app = FastAPI(title="MCP Cybersecurity Server")
+
+class ScanRequest(BaseModel):
+    target: str
+
+class QueryRequest(BaseModel):
+    question: str
+
+@app.post("/scan")
+def scan(req: ScanRequest):
+    """Run the MCP agent to scan the given target."""
+    result = invoke_agent(f"Scan the IP address {req.target}")
+    return {"result": result}
+
+
+@app.post("/agent")
+def agent(req: QueryRequest):
+    """Run an arbitrary question through the MCP agent."""
+    return {"result": invoke_agent(req.question)}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- expand `mcp_servers_examples` with a LangChain based MCP agent
- connect the FastAPI server to the new agent
- document how to use the agent and server

## Testing
- `pytest -q`
