### PR TITLE
Add MCP server example

### DIFF
--- a/part5_agents_and_tools/mcp_servers_examples/README.md
+++ b/part5_agents_and_tools/mcp_servers_examples/README.md
@@ -1,0 +1,40 @@
+# MCP Server Cybersecurity Example
+
+This folder contains an example **MCP (Master Control Program)** server inspired
+by the "MCP From Scratch" article and adapted for cybersecurity.  The server
+exposes endpoints for lightweight port scanning using `nmap` and for asking an
+agent questions.  The agent can decide to invoke the scanning tool when needed.
+
+> **Note**: The scanning functionality performs a fast `nmap` scan.  Use it only
+> on systems you have permission to test.
+
+## Files
+
+- `mcp_server.py` – FastAPI server exposing `/scan` and `/agent` endpoints.
+- `mcp_cyber_agent.py` – LangChain agent with a port scanning tool.
+
+## Usage
+
+1. Install the requirements (including `nmap`):
+   ```bash
+   sudo apt-get install nmap
+   pip install fastapi uvicorn langchain langchain-openai python-nmap python-dotenv
+   ```
+
+2. Run the server:
+   ```bash
+   python mcp_server.py
+   ```
+
+3. Send a request to the `/scan` endpoint. For example:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" -d '{"target": "192.168.1.1"}' http://localhost:8000/scan
+   ```
+
+   The response contains a JSON object with the list of open ports.
+
+4. Ask the agent a question:
+   ```bash
+   curl -X POST -H "Content-Type: application/json" -d '{"question": "Scan 192.168.1.1"}' http://localhost:8000/agent
+   ```
+

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_cyber_agent.py
@@ -1,0 +1,60 @@
+from dotenv import load_dotenv
+from langchain import hub
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.tools import Tool
+from langchain.tools import StructuredTool
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+import nmap
+import datetime
+
+load_dotenv()
+
+
+def get_current_time() -> str:
+    """Return the current time in H:MM AM/PM format."""
+    now = datetime.datetime.now()
+    return now.strftime("%I:%M %p")
+
+
+def scan_ports(target: str):
+    """Perform a fast nmap scan of the target and return open ports."""
+    nm = nmap.PortScanner()
+    nm.scan(target, arguments="-F")
+    open_ports = []
+    for host in nm.all_hosts():
+        for proto in nm[host].all_protocols():
+            open_ports.extend(nm[host][proto].keys())
+    return sorted(set(open_ports))
+
+
+class ScanInput(BaseModel):
+    target: str = Field(..., description="IP address or host to scan")
+
+
+tools = [
+    Tool(name="Time", func=get_current_time, description="Get the current time"),
+    StructuredTool.from_function(
+        name="PortScanner",
+        func=scan_ports,
+        description="Scan a host for open ports",
+        args_schema=ScanInput,
+    ),
+]
+
+prompt = hub.pull("hwchase17/react")
+llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+
+agent = create_react_agent(
+    llm=llm,
+    tools=tools,
+    prompt=prompt,
+    stop_sequence=True,
+)
+
+agent_executor = AgentExecutor.from_agent_and_tools(
+    agent=agent,
+    tools=tools,
+    verbose=True,
+)
+

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
@@ -1,0 +1,52 @@
+"""MCP server example for cybersecurity tasks.
+
+This FastAPI application exposes endpoints to perform lightweight port scanning
+and to interact with an agent capable of deciding when to run a scan.  The
+implementation is inspired by the "MCP From Scratch" article but adapted for
+cybersecurity use cases.
+"""
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import nmap
+
+from mcp_cyber_agent import agent_executor
+
+app = FastAPI(title="MCP Cybersecurity Server")
+
+class ScanRequest(BaseModel):
+    target: str
+
+
+class AgentRequest(BaseModel):
+    question: str
+
+@app.post("/scan")
+def scan(req: ScanRequest):
+    """Perform a fast nmap scan and return open ports."""
+    nm = nmap.PortScanner()
+    try:
+        nm.scan(req.target, arguments="-F")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    open_ports = []
+    for host in nm.all_hosts():
+        for proto in nm[host].all_protocols():
+            open_ports.extend(nm[host][proto].keys())
+    return {"target": req.target, "open_ports": sorted(set(open_ports))}
+
+
+@app.post("/agent")
+def agent(req: AgentRequest):
+    """Ask the MCP agent a question. It may choose to run a scan."""
+    try:
+        result = agent_executor.invoke({"input": req.question})
+        return result
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
+++ b/part5_agents_and_tools/mcp_servers_examples/mcp_server.py
@@ -24,19 +24,11 @@ class AgentRequest(BaseModel):
 @app.post("/scan")
 def scan(req: ScanRequest):
     """Perform a fast nmap scan and return open ports."""
-    nm = nmap.PortScanner()
     try:
-        nm.scan(req.target, arguments="-F")
+        open_ports = scan_ports(req.target, arguments="-F")
+        return {"target": req.target, "open_ports": sorted(set(open_ports))}
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
-
-    open_ports = []
-    for host in nm.all_hosts():
-        for proto in nm[host].all_protocols():
-            open_ports.extend(nm[host][proto].keys())
-    return {"target": req.target, "open_ports": sorted(set(open_ports))}
-
-
 @app.post("/agent")
 def agent(req: AgentRequest):
     """Ask the MCP agent a question. It may choose to run a scan."""


### PR DESCRIPTION
## Summary
- add `mcp_servers_examples` directory with a README
- include a minimal FastAPI server example that mocks a scan endpoint for cybersecurity
