### PR TITLE
fix: update model name to llava and modify sentiment analysis test input

### DIFF
--- a/part1_basic_examples_no_rag/huggingface_example.py
+++ b/part1_basic_examples_no_rag/huggingface_example.py
@@ -16,6 +16,6 @@ from transformers import pipeline
 
 # Example usage
 classifier = pipeline("sentiment-analysis")
-result = classifier("Omar, I hate using Hugging Face!")
+result = classifier("Omar, I LOVE using Hugging Face!")
 print(result)
 

--- a/part1_basic_examples_no_rag/ollama/basic_ollama_api.py
+++ b/part1_basic_examples_no_rag/ollama/basic_ollama_api.py
@@ -38,7 +38,7 @@ def streaming_chat(messages: list, model: str = "llama3.2"):
 def analyze_image(image_path: str, question: str):
     with open(image_path, 'rb') as file:
         response = ollama.chat(
-            model='llama3.2',
+            model='llava',
             messages=[{
                 'role': 'user',
                 'content': question,


### PR DESCRIPTION
This pull request includes two small changes to improve example usage and update the model used in a function.

* Updated sentiment analysis example in `huggingface_example.py` to use a positive sentiment statement instead of a negative one.
* Changed the model parameter in the `analyze_image` function in `basic_ollama_api.py` from `llama3.2` to `llava` for image analysis.