### PR TITLE
feat: implement message placeholders for chat history in prompt templ…

### DIFF
--- a/part2_prompt_templates/messages_placeholders.py
+++ b/part2_prompt_templates/messages_placeholders.py
@@ -1,0 +1,37 @@
+# Messages Placeholders
+# Messages placeholders allow you to include a list of messages in a prompt template.
+# The explanation is available at: https://cybercopilot.org/QOrM2Qm
+# Instructor: Omar Santos @santosomar
+
+# LangChain Chat Prompt Template Documents: https://python.langchain.com/docs/how_to/#prompt-templates 
+# OpenAI Chat Model Documents: https://python.langchain.com/docs/how_to/#chat-models
+# LangChain Expression Language (LCEL): https://python.langchain.com/docs/how_to/#langchain-expression-language-lcel
+
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.messages import HumanMessage, AIMessage
+from langchain_openai import ChatOpenAI
+from dotenv import load_dotenv
+
+# Load environment variables from .env
+load_dotenv()
+
+# Create a ChatOpenAI model
+model = ChatOpenAI(model="gpt-4.1-mini")
+prompt_with_history = ChatPromptTemplate.from_messages([
+ ("system", "You are a helpful assistant."),
+ MessagesPlaceholder(variable_name="chat_history"),
+ ("user", "{user_input}")
+])
+history = [
+ HumanMessage(content="What is a CVE?"),
+ AIMessage(content="A CVE is a Common Vulnerabilities and Exposures identifier."),
+ HumanMessage(content="What is a Common Vulnerabilities and Exposures identifier?")
+]
+final_prompt_value = prompt_with_history.invoke({
+ "chat_history": history,
+ "user_input": "What is a CVE?"
+})
+print(final_prompt_value.to_messages())
+
+result = model.invoke(final_prompt_value)
+print(result.content)


### PR DESCRIPTION
This pull request introduces a new feature in the `messages_placeholders.py` file to demonstrate the use of message placeholders in LangChain's chat prompt templates. It includes an example implementation of a chat model that maintains conversation history and generates responses using OpenAI's GPT-4.1-mini model.

### Key changes in `messages_placeholders.py`:

* **Integration of LangChain Components**:
  - Added imports for `ChatPromptTemplate`, `MessagesPlaceholder`, `HumanMessage`, and `AIMessage` from LangChain libraries to enable structured prompt creation.

* **Environment Setup**:
  - Included the `dotenv` library to load environment variables from a `.env` file, ensuring secure and flexible configuration management.

* **Chat Model Setup**:
  - Created a `ChatOpenAI` model instance using the `gpt-4.1-mini` model for generating AI responses.

* **Prompt Template with History**:
  - Defined a `ChatPromptTemplate` with a `MessagesPlaceholder` to include conversation history dynamically. This enables the model to consider prior exchanges when generating responses.

* **Example Usage**:
  - Implemented a demonstration of the chat model by providing a conversation history and user input, generating a final prompt, and invoking the model to produce a response. The result is printed to…ates