### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Omar Santos
+Copyright (c) 2025, Omar Santos
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
This pull request updates the copyright year in the `LICENSE` file to reflect the current year. 

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L3-R3): Updated the copyright year from 2024 to 2025.