### PR TITLE
refactor: remove unused imports BaseMessage and MessagesPlaceholder f…

### DIFF
--- a/part5_agents_and_tools/agent_deep_dive/langgraph/ethical_hacking_agent.py
+++ b/part5_agents_and_tools/agent_deep_dive/langgraph/ethical_hacking_agent.py
@@ -10,8 +10,8 @@ import uuid
 from typing import TypedDict, Annotated
 
 from dotenv import load_dotenv
-from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.messages import HumanMessage, AIMessage
+from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.memory import MemorySaver


### PR DESCRIPTION
Fixes #53 

This pull request makes a minor adjustment to the imports in `ethical_hacking_agent.py` to clean up unused dependencies.

* [`part5_agents_and_tools/agent_deep_dive/langgraph/ethical_hacking_agent.py`](diffhunk://#diff-82b5a089001a60dcbe08e8af5c5bd82867de7f8019f93869ea6d15741e7ec540L13-R14): Removed the unused `BaseMessage` and `MessagesPlaceholder` imports to streamline the code.