### PR TITLE
Make DeepAgents SOC example self-contained with uv

### DIFF
--- a/part5_agents_and_tools/deepagents_example/soc_agent.py
+++ b/part5_agents_and_tools/deepagents_example/soc_agent.py
@@ -21,6 +21,20 @@
 # example is completely safe to run. Only the LLM calls require network + an API key.
 #
 # Instructor: Omar Santos @santosomar
+#
+# Run it self-contained with uv (no project sync needed):
+#   uv run part5_agents_and_tools/deepagents_example/soc_agent.py
+# The PEP 723 metadata block below lets uv build an isolated environment with
+# only this script's dependencies.
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "deepagents",
+#     "langchain-openai",
+#     "python-dotenv",
+# ]
+# ///
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Adds a PEP 723 inline script metadata block to `part5_agents_and_tools/deepagents_example/soc_agent.py` declaring its dependencies (`deepagents`, `langchain-openai`, `python-dotenv`).
- This lets `uv run` execute the script in an **isolated environment**, so it works on platforms where a full project `uv sync` cannot complete (e.g. Intel macOS, where `torch` has no compatible wheel) and regardless of the `.python-version` pin.

## Problem being fixed

Previously the example failed two ways:

```
$ .venv/bin/python .../soc_agent.py
ModuleNotFoundError: No module named 'dotenv'

$ uv run .../soc_agent.py
error: ... resolved to Python 3.12.6, which is incompatible with the project's
Python requirement: `>=3.13`.
```

The script only needs three lightweight dependencies and none of the heavy/unsatisfiable project ones, so isolating it is the most robust fix.

## How to run

```bash
export OPENAI_API_KEY="your-key"
uv run part5_agents_and_tools/deepagents_example/soc_agent.py
```

## Test plan

- [x] `uv run` builds the isolated environment and the script runs past imports and the banner (verified; it only stops at the live OpenAI call when no valid key is set)
- [x] Confirmed `uv run` ignores the unsatisfiable project dependencies when inline metadata is present
- [ ] End-to-end run with a valid `OPENAI_API_KEY`

Closes #122

Made with [Cursor](https://cursor.com)