### PR TITLE
Quiet LangSmith 403 tracing noise in DeepAgents SOC example

### DIFF
--- a/part5_agents_and_tools/deepagents_example/soc_agent.py
+++ b/part5_agents_and_tools/deepagents_example/soc_agent.py
@@ -39,12 +39,21 @@
 from __future__ import annotations
 
 import json
+import os
 
 from dotenv import load_dotenv
 from deepagents import create_deep_agent
 
 # Load OPENAI_API_KEY (and friends) from a .env file if present.
 load_dotenv()
+
+# Quiet LangSmith tracing unless it is explicitly configured with an API key.
+# Without a valid key/plan, every run upload returns HTTP 403 and floods the
+# console with "Failed to multipart ingest runs" noise. If you DO have a
+# LangSmith key set, tracing is left enabled so you can observe the run.
+if not (os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGCHAIN_API_KEY")):
+    os.environ["LANGSMITH_TRACING"] = "false"
+    os.environ["LANGCHAIN_TRACING_V2"] = "false"
 
 # The provider:model string deepagents will use for the supervisor and, by
 # default, every subagent. Keep it consistent with the rest of the repo.


### PR DESCRIPTION
## Summary

- Disables LangSmith/LangChain tracing in `part5_agents_and_tools/deepagents_example/soc_agent.py` when no LangSmith API key is present in the environment.
- Prevents the console from being flooded with `403 Forbidden - no plan found` errors from run uploads when tracing is enabled but not properly configured.
- Tracing is left enabled when a `LANGSMITH_API_KEY` (or `LANGCHAIN_API_KEY`) is set, so users who intentionally use LangSmith still get full traces.

## Problem being fixed

```
Failed to multipart ingest runs: langsmith.utils.LangSmithError: Failed to POST
https://api.smith.langchain.com/runs/multipart ... 403 ... "Forbidden - no plan found"
```

The uploads are harmless to the agent run, but the repeated noise is confusing for learners who haven't set up LangSmith.

## Change

```python
if not (os.environ.get("LANGSMITH_API_KEY") or os.environ.get("LANGCHAIN_API_KEY")):
    os.environ["LANGSMITH_TRACING"] = "false"
    os.environ["LANGCHAIN_TRACING_V2"] = "false"
```

## Test plan

- [x] With no LangSmith key set, the example runs without the 403 ingest errors
- [x] Lint clean (the two `dotenv`/`deepagents` import warnings are pre-existing artifacts of the empty project venv, not introduced here)
- [ ] With a valid `LANGSMITH_API_KEY`, traces still appear in LangSmith

Closes #124

Made with [Cursor](https://cursor.com)